### PR TITLE
Fixes missing reference to 'self'

### DIFF
--- a/lib/passport-twitter-token/strategy.js
+++ b/lib/passport-twitter-token/strategy.js
@@ -75,21 +75,22 @@ TwitterTokenStrategy.prototype.authenticate = function(req, options) {
   if (req.query && req.query.denied) {
     return this.fail();
   }
-  
+
   var token = req.body.token || req.query.token;
   var tokenSecret = req.body.token_secret || req.query.token_secret;
   var userId = req.body.user_id || req.query.user_id;
   var params = { user_id: userId };
-  
+  var self = this;
+
   self._loadUserProfile(token, tokenSecret, params, function(err, profile) {
     if (err) { return self.error(err); };
-    
+
     function verified(err, user, info) {
       if (err) { return self.error(err); }
       if (!user) { return self.fail(info); }
       self.success(user, info);
     }
-    
+
     var arity = self._verify.length;
     if (arity == 5) {
       self._verify(token, tokenSecret, params, profile, verified);


### PR DESCRIPTION
Hi Jared,

Thanks for putting together passport. Just started playing with it and noticed that `self`isn't defined in authenticate. It was throwing an error in my app.

Thanks,
Dustin
